### PR TITLE
[codex] 添加电量查询 Key 接口

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,6 +3,7 @@ import { cors } from "hono/cors";
 import auth from "./routes/auth";
 import rooms from "./routes/rooms";
 import agent from "./routes/agent";
+import electricity from "./routes/electricity";
 import user from "./routes/user";
 import { Bindings, Variables } from "./types";
 
@@ -16,6 +17,7 @@ app.get("/", c => {
 
 app.route("/auth", auth);
 app.route("/rooms", rooms);
+app.route("/electricity", electricity);
 app.route("/agent", agent);
 app.route("/user", user);
 

--- a/server/src/local.ts
+++ b/server/src/local.ts
@@ -4,6 +4,7 @@ import { cors } from "hono/cors";
 import auth from "./routes/auth";
 import rooms from "./routes/rooms";
 import agent from "./routes/agent";
+import electricity from "./routes/electricity";
 import user from "./routes/user";
 import { getLocalDb, D1Adapter } from "./db";
 
@@ -67,6 +68,7 @@ app.get("/", c => {
 
 app.route("/auth", auth);
 app.route("/rooms", rooms);
+app.route("/electricity", electricity);
 app.route("/agent", agent);
 app.route("/user", user);
 

--- a/server/src/routes/electricity.ts
+++ b/server/src/routes/electricity.ts
@@ -120,7 +120,7 @@ app.post("/query-key", authMiddleware, async c => {
 });
 
 app.get("/query", async c => {
-    const token = getBearerToken(c.req.header("Authorization"));
+    const token = getBearerToken(c.req.header("Authorization")) || c.req.query("key");
     if (!token) return c.json({ error: "缺少查询 Key" }, 401);
 
     let payload: unknown;

--- a/server/src/routes/electricity.ts
+++ b/server/src/routes/electricity.ts
@@ -1,0 +1,179 @@
+import { Hono } from "hono";
+import { sign, verify } from "hono/jwt";
+import { authMiddleware } from "../middlewares";
+import { Bindings, Variables } from "../types";
+
+const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+const QUERY_KEY_TYPE = "electricity_query";
+const QUERY_KEY_SCOPE = "read:electricity";
+const MAX_QUERY_KEY_ROOMS = 20;
+
+const EXPIRES_IN_SECONDS: Record<string, number> = {
+    "7d": 60 * 60 * 24 * 7,
+    "30d": 60 * 60 * 24 * 30,
+    "90d": 60 * 60 * 24 * 90,
+    "365d": 60 * 60 * 24 * 365,
+    forever: 60 * 60 * 24 * 365 * 10,
+};
+
+type QueryKeyPayload = {
+    exp: number;
+    jti: string;
+    rids: number[];
+    scope: string;
+    typ: string;
+    uid: number;
+};
+
+function getQuerySecret(jwtSecret: string): string {
+    return `${jwtSecret}:electricity-query`;
+}
+
+function getBearerToken(authHeader: string | undefined): string | null {
+    if (!authHeader) return null;
+    const [scheme, token] = authHeader.split(" ");
+    if (scheme !== "Bearer" || !token) return null;
+    return token;
+}
+
+function normalizeRoomIds(roomIds: unknown): number[] {
+    if (!Array.isArray(roomIds)) return [];
+
+    const normalized = roomIds.map(id => Number(id)).filter(id => Number.isInteger(id) && id > 0);
+
+    return [...new Set(normalized)];
+}
+
+function makePlaceholders(count: number): string {
+    return Array.from({ length: count }, () => "?").join(", ");
+}
+
+function toExpiresAt(exp: number): string {
+    return new Date(exp * 1000).toISOString();
+}
+
+function isQueryPayload(payload: unknown): payload is QueryKeyPayload {
+    if (!payload || typeof payload !== "object") return false;
+    const candidate = payload as Partial<QueryKeyPayload>;
+    return (
+        candidate.typ === QUERY_KEY_TYPE &&
+        candidate.scope === QUERY_KEY_SCOPE &&
+        typeof candidate.uid === "number" &&
+        Number.isInteger(candidate.uid) &&
+        Array.isArray(candidate.rids) &&
+        candidate.rids.every(id => Number.isInteger(id) && id > 0) &&
+        typeof candidate.exp === "number"
+    );
+}
+
+app.post("/query-key", authMiddleware, async c => {
+    const user = c.get("user");
+    const body = await c.req.json<{ expires_in?: string; room_ids?: unknown }>().catch(() => null);
+
+    const roomIds = normalizeRoomIds(body?.room_ids);
+    if (roomIds.length === 0) return c.json({ error: "请选择至少一个房间" }, 400);
+    if (roomIds.length > MAX_QUERY_KEY_ROOMS) {
+        return c.json({ error: `单个查询 Key 最多支持 ${MAX_QUERY_KEY_ROOMS} 个房间` }, 400);
+    }
+
+    const expiresIn = body?.expires_in || "90d";
+    const ttl = EXPIRES_IN_SECONDS[expiresIn];
+    if (!ttl) return c.json({ error: "不支持的有效期" }, 400);
+
+    const placeholders = makePlaceholders(roomIds.length);
+    const subscribed = await c.env.DB.prepare(
+        `
+        SELECT room_id
+        FROM subscriptions
+        WHERE user_id = ?
+          AND is_active = 1
+          AND room_id IN (${placeholders})
+    `
+    )
+        .bind(user.id, ...roomIds)
+        .all<{ room_id: number }>();
+
+    const subscribedIds = subscribed.results.map(row => row.room_id);
+    if (subscribedIds.length !== roomIds.length) {
+        return c.json({ error: "包含未订阅或已停用的房间" }, 403);
+    }
+
+    const exp = Math.floor(Date.now() / 1000) + ttl;
+    const payload: QueryKeyPayload = {
+        exp,
+        jti: crypto.randomUUID(),
+        rids: roomIds,
+        scope: QUERY_KEY_SCOPE,
+        typ: QUERY_KEY_TYPE,
+        uid: user.id,
+    };
+
+    const key = await sign(payload, getQuerySecret(c.env.JWT_SECRET), "HS256");
+    return c.json({
+        expires_at: toExpiresAt(exp),
+        key,
+        room_ids: roomIds,
+        scope: QUERY_KEY_SCOPE,
+        typ: QUERY_KEY_TYPE,
+    });
+});
+
+app.get("/query", async c => {
+    const token = getBearerToken(c.req.header("Authorization"));
+    if (!token) return c.json({ error: "缺少查询 Key" }, 401);
+
+    let payload: unknown;
+    try {
+        payload = await verify(token, getQuerySecret(c.env.JWT_SECRET), "HS256");
+    } catch {
+        return c.json({ error: "查询 Key 无效或已过期" }, 401);
+    }
+
+    if (!isQueryPayload(payload)) return c.json({ error: "查询 Key 类型无效" }, 401);
+    if (payload.exp <= Math.floor(Date.now() / 1000)) return c.json({ error: "查询 Key 无效或已过期" }, 401);
+
+    const roomIds = normalizeRoomIds(payload.rids);
+    if (roomIds.length === 0) return c.json({ rooms: [] });
+
+    const placeholders = makePlaceholders(roomIds.length);
+    const rooms = await c.env.DB.prepare(
+        `
+        SELECT
+            r.id,
+            r.full_name,
+            r.last_electricity,
+            r.last_query_status,
+            r.next_query_time,
+            s.alias_name,
+            s.notification_threshold,
+            s.is_active
+        FROM subscriptions s
+        JOIN rooms r ON s.room_id = r.id
+        WHERE s.user_id = ?
+          AND s.is_active = 1
+          AND s.room_id IN (${placeholders})
+        ORDER BY s.id ASC
+    `
+    )
+        .bind(payload.uid, ...roomIds)
+        .all<{
+            alias_name: string | null;
+            full_name: string | null;
+            id: number;
+            is_active: number;
+            last_electricity: number | null;
+            last_query_status: string | null;
+            next_query_time: string | null;
+            notification_threshold: number;
+        }>();
+
+    return c.json({
+        rooms: rooms.results.map(room => ({
+            ...room,
+            unit: "kWh",
+        })),
+    });
+});
+
+export default app;

--- a/server/src/routes/electricity.ts
+++ b/server/src/routes/electricity.ts
@@ -141,9 +141,16 @@ app.get("/query", async c => {
         `
         SELECT
             r.id,
+            r.system_id,
+            r.area_id,
+            r.building_id,
+            r.floor_id,
+            r.room_id,
             r.full_name,
+            r.last_query_time,
             r.last_electricity,
             r.last_query_status,
+            r.last_message,
             r.next_query_time,
             s.alias_name,
             s.notification_threshold,
@@ -159,13 +166,20 @@ app.get("/query", async c => {
         .bind(payload.uid, ...roomIds)
         .all<{
             alias_name: string | null;
+            area_id: string;
+            building_id: string | null;
+            floor_id: string | null;
             full_name: string | null;
             id: number;
             is_active: number;
             last_electricity: number | null;
+            last_message: string | null;
             last_query_status: string | null;
+            last_query_time: string | null;
             next_query_time: string | null;
             notification_threshold: number;
+            room_id: string;
+            system_id: string;
         }>();
 
     return c.json({

--- a/web/src/views/Dashboard.vue
+++ b/web/src/views/Dashboard.vue
@@ -437,6 +437,109 @@
                             </el-form>
                         </el-collapse-item>
                     </el-collapse>
+
+                    <div class="settings-section-title">高级设置</div>
+
+                    <el-collapse v-model="notifyCollapseActive" class="notify-collapse">
+                        <el-collapse-item title="生成查询 Key" name="advanced">
+                            <el-form class="notify-form" label-width="140px" label-position="left">
+                                <el-form-item label="生成查询 Key">
+                                    <div class="notify-field">
+                                        <div class="query-key-section">
+                                            <div class="query-key-section-label">房间</div>
+                                            <div class="query-key-field">
+                                                <el-checkbox-group
+                                                    v-model="queryKeyRoomIds"
+                                                    class="query-key-room-list"
+                                                >
+                                                    <el-checkbox
+                                                        v-for="room in activeRooms"
+                                                        :key="room.id"
+                                                        :label="room.id"
+                                                        class="query-key-room-item"
+                                                    >
+                                                        <span>
+                                                            {{
+                                                                spacingText(
+                                                                    room.alias_name ||
+                                                                        room.full_name ||
+                                                                        `房间 ${room.id}`
+                                                                )
+                                                            }}
+                                                        </span>
+                                                        <span
+                                                            v-if="room.full_name && room.alias_name"
+                                                            class="query-key-room-full-name"
+                                                        >
+                                                            {{ spacingText(room.full_name) }}
+                                                        </span>
+                                                    </el-checkbox>
+                                                </el-checkbox-group>
+                                                <div v-if="activeRooms.length === 0" class="form-hint">
+                                                    暂无已开启订阅的房间。
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div class="query-key-section">
+                                            <div class="query-key-section-label">有效期</div>
+                                            <div class="query-key-field">
+                                                <el-radio-group v-model="queryKeyExpiresIn">
+                                                    <el-radio-button label="7d">7 天</el-radio-button>
+                                                    <el-radio-button label="30d">30 天</el-radio-button>
+                                                    <el-radio-button label="90d">90 天</el-radio-button>
+                                                    <el-radio-button label="365d">1 年</el-radio-button>
+                                                    <el-radio-button label="forever">永久</el-radio-button>
+                                                </el-radio-group>
+                                                <div class="notify-switch-row">
+                                                    <el-button
+                                                        type="primary"
+                                                        size="small"
+                                                        :loading="queryKeyLoading"
+                                                        :disabled="
+                                                            queryKeyRoomIds.length === 0 || activeRooms.length === 0
+                                                        "
+                                                        @click="generateQueryKey"
+                                                        >生成</el-button
+                                                    >
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <div v-if="generatedQueryKey" class="query-key-section">
+                                            <div class="query-key-section-label">Key</div>
+                                            <div class="query-key-field">
+                                                <el-input
+                                                    :model-value="generatedQueryKey"
+                                                    type="textarea"
+                                                    :rows="5"
+                                                    readonly
+                                                />
+                                                <div class="query-key-copy-row">
+                                                    <span class="form-hint">仅显示一次，关闭后需要重新生成。</span>
+                                                    <el-button
+                                                        :icon="CopyDocument"
+                                                        type="primary"
+                                                        plain
+                                                        size="small"
+                                                        @click="copyText(generatedQueryKey)"
+                                                        >复制</el-button
+                                                    >
+                                                </div>
+                                                <div class="form-hint">
+                                                    调用：GET /api/electricity/query，Header 使用 Authorization: Bearer
+                                                    上方 Key。
+                                                </div>
+                                                <div v-if="queryKeyExpiresAt" class="form-hint">
+                                                    过期时间：{{ queryKeyExpiresAt }}
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </el-form-item>
+                            </el-form>
+                        </el-collapse-item>
+                    </el-collapse>
                 </div>
 
                 <template #footer>
@@ -493,7 +596,7 @@ import { ElMessage, ElMessageBox } from 'element-plus';
 import axios from 'axios';
 import { spacingText } from '../utils/pangu';
 import { useTheme } from '../composables/useTheme';
-import { Moon, Sunny, Monitor, Refresh, Setting, Document } from '@element-plus/icons-vue';
+import { Moon, Sunny, Monitor, Refresh, Setting, Document, CopyDocument } from '@element-plus/icons-vue';
 
 const LogoutDoorIcon = defineComponent({
     name: 'LogoutDoorIcon',
@@ -556,6 +659,11 @@ const showAddDialog = ref(false);
 const isEditMode = ref(false);
 const editingRoomId = ref<number | ''>('');
 const submitLoading = ref(false);
+const queryKeyLoading = ref(false);
+const queryKeyRoomIds = ref<number[]>([]);
+const queryKeyExpiresIn = ref('90d');
+const generatedQueryKey = ref('');
+const queryKeyExpiresAt = ref('');
 
 const showNotifyDialog = ref(false);
 const notifyCollapseActive = ref<string[]>([]);
@@ -585,6 +693,7 @@ const wechatTemplateContent =
 const wechatTemplateTitle = 'TJUEcard';
 
 const dingtalkSwitchDisabled = computed(() => !notifyForm.value.dingtalk_webhook_url.trim());
+const activeRooms = computed(() => rooms.value.filter(room => (room.is_active ?? 1) === 1));
 
 type TutorialSection = 'dingtalk-webhook' | 'wechat-email' | 'wechat-test-account';
 
@@ -595,6 +704,49 @@ const openTutorial = (section: TutorialSection) => {
 
 const openTutorialsPage = () => {
     router.push('/tutorials');
+};
+
+const resetQueryKeyDialog = () => {
+    queryKeyLoading.value = false;
+    queryKeyRoomIds.value = [];
+    queryKeyExpiresIn.value = '90d';
+    generatedQueryKey.value = '';
+    queryKeyExpiresAt.value = '';
+};
+
+const formatQueryKeyExpiresAt = (expiresAt: string) => {
+    const date = new Date(expiresAt);
+    if (isNaN(date.getTime())) return expiresAt;
+
+    const year = date.getFullYear();
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+    const hours = date.getHours().toString().padStart(2, '0');
+    const minutes = date.getMinutes().toString().padStart(2, '0');
+    return `${year}-${month}-${day} ${hours}:${minutes}`;
+};
+
+const generateQueryKey = async () => {
+    if (queryKeyRoomIds.value.length === 0) {
+        ElMessage.warning('请选择至少一个房间');
+        return;
+    }
+
+    queryKeyLoading.value = true;
+    try {
+        const res = await api.post('/electricity/query-key', {
+            expires_in: queryKeyExpiresIn.value,
+            room_ids: queryKeyRoomIds.value,
+        });
+        generatedQueryKey.value = res.data.key || '';
+        queryKeyExpiresAt.value = res.data.expires_at ? formatQueryKeyExpiresAt(res.data.expires_at) : '';
+        ElMessage.success('查询 Key 已生成');
+    } catch (e) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ElMessage.error((e as any).response?.data?.error || '生成查询 Key 失败');
+    } finally {
+        queryKeyLoading.value = false;
+    }
 };
 
 watch(
@@ -702,6 +854,7 @@ const openNotifyDialog = async () => {
     showNotifyDialog.value = true;
     notifyCollapseActive.value = [];
     notifyReady.value = false;
+    queryKeyRoomIds.value = activeRooms.value.map(room => room.id);
     await loadNotifySettings();
     // Auto sync followers from WeChat on open (silent, non-blocking).
     if (wechatBound.value) void refreshWeChatFollowers({ silent: true });
@@ -716,6 +869,7 @@ const notifyDialogClosed = () => {
     wechatHasAppSecret.value = false;
     wechatFollowersSyncError.value = '';
     resetWeChatForm();
+    resetQueryKeyDialog();
 };
 
 const copyText = async (text: string) => {
@@ -1457,6 +1611,90 @@ onUnmounted(() => {
     min-width: 0;
 }
 
+.settings-section-title {
+    color: #667eea;
+    font-weight: 600;
+    font-size: 18px;
+    line-height: 1.4;
+    margin: 18px 0 10px;
+}
+
+.query-key-field {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 0;
+}
+
+.query-key-section {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 56px minmax(0, 1fr);
+    column-gap: 12px;
+    align-items: flex-start;
+}
+
+.query-key-section-label {
+    color: var(--el-text-color-secondary);
+    font-size: 13px;
+    line-height: 32px;
+}
+
+.query-key-room-list {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr));
+    gap: 8px;
+}
+
+.query-key-room-item {
+    width: 100%;
+    height: auto;
+    min-height: 54px;
+    line-height: 1.25;
+    margin-right: 0;
+    padding: 8px 10px;
+    border: 1px solid var(--el-border-color-lighter);
+    border-radius: 8px;
+    box-sizing: border-box;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: flex-start;
+    white-space: normal;
+}
+
+.query-key-room-item :deep(.el-checkbox__label) {
+    width: 100%;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    line-height: 1.25;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.query-key-room-item :deep(.el-checkbox__input) {
+    margin-top: 2px;
+}
+
+.query-key-room-full-name {
+    color: var(--el-text-color-secondary);
+    font-size: 12px;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+}
+
+.query-key-copy-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
 .threshold-field {
     width: 100%;
     display: flex;
@@ -1668,6 +1906,31 @@ onUnmounted(() => {
         flex: 1;
         max-width: 120px;
     }
+
+    .query-key-section {
+        grid-template-columns: minmax(0, 1fr);
+        row-gap: 4px;
+    }
+
+    .query-key-section-label {
+        line-height: 1.4;
+    }
+
+    .query-key-room-list {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .query-key-field :deep(.el-radio-group) {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        width: 100%;
+    }
+
+    .query-key-field :deep(.el-radio-button__inner) {
+        width: 100%;
+        padding-left: 8px;
+        padding-right: 8px;
+    }
 }
 
 /* Extra small screens */
@@ -1709,6 +1972,15 @@ onUnmounted(() => {
 
     :deep(.dialog-footer .el-button) {
         font-size: 14px;
+    }
+
+    .query-key-room-item {
+        min-height: 54px;
+        padding: 8px;
+    }
+
+    .query-key-field :deep(.el-radio-group) {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 }
 

--- a/web/src/views/Dashboard.vue
+++ b/web/src/views/Dashboard.vue
@@ -509,6 +509,18 @@
                                         <div v-if="generatedQueryKey" class="query-key-section">
                                             <div class="query-key-section-label">Key</div>
                                             <div class="query-key-field">
+                                                <el-input :model-value="queryKeyUrl" readonly />
+                                                <div class="query-key-copy-row">
+                                                    <span class="form-hint">可直接复制该 URL 作为查询地址。</span>
+                                                    <el-button
+                                                        :icon="CopyDocument"
+                                                        type="primary"
+                                                        plain
+                                                        size="small"
+                                                        @click="copyText(queryKeyUrl)"
+                                                        >复制 URL</el-button
+                                                    >
+                                                </div>
                                                 <el-input
                                                     :model-value="generatedQueryKey"
                                                     type="textarea"
@@ -527,8 +539,8 @@
                                                     >
                                                 </div>
                                                 <div class="form-hint">
-                                                    调用：GET /api/electricity/query，Header 使用 Authorization: Bearer
-                                                    上方 Key。
+                                                    也可调用：GET {{ queryKeyEndpoint }}，Header 使用 Authorization:
+                                                    Bearer 上方 Key。
                                                 </div>
                                                 <div v-if="queryKeyExpiresAt" class="form-hint">
                                                     过期时间：{{ queryKeyExpiresAt }}
@@ -694,6 +706,13 @@ const wechatTemplateTitle = 'TJUEcard';
 
 const dingtalkSwitchDisabled = computed(() => !notifyForm.value.dingtalk_webhook_url.trim());
 const activeRooms = computed(() => rooms.value.filter(room => (room.is_active ?? 1) === 1));
+const queryKeyEndpoint = computed(() => new URL('/api/electricity/query', window.location.origin).toString());
+const queryKeyUrl = computed(() => {
+    if (!generatedQueryKey.value) return '';
+    const url = new URL(queryKeyEndpoint.value);
+    url.searchParams.set('key', generatedQueryKey.value);
+    return url.toString();
+});
 
 type TutorialSection = 'dingtalk-webhook' | 'wechat-email' | 'wechat-test-account';
 


### PR DESCRIPTION
## 变更内容

- 新增 `server/src/routes/electricity.ts` 路由模块。
- 在生产入口 `server/src/index.ts` 和本地入口 `server/src/local.ts` 挂载 `/electricity` 路由。
- 新增 `POST /api/electricity/query-key`：登录用户可为已开启订阅的房间生成查询 Key，支持 `7d`、`30d`、`90d`、`365d`、`forever` 有效期，单个 Key 最多绑定 20 个房间。
- 查询 Key 使用独立派生密钥签名，payload 中包含用户 ID、房间 ID 列表、scope、类型、过期时间和随机 `jti`。
- 新增 `GET /api/electricity/query`：支持通过 `Authorization: Bearer <key>` 或 URL 参数 `?key=` 查询，校验 Key 类型、scope、过期时间和房间授权后返回房间电量数据。
- `/api/electricity/query` 返回数据包含订阅信息、电量状态和房间定位字段：`id`、`alias_name`、`full_name`、`system_id`、`area_id`、`building_id`、`floor_id`、`room_id`、`last_query_time`、`last_query_status`、`last_message`、`last_electricity`、`next_query_time`、`notification_threshold`、`is_active`、`unit`。
- 在 Dashboard 通知设置弹窗中新增“高级设置 / 生成查询 Key”区域。
- 前端支持选择已开启订阅的房间、选择 Key 有效期、生成 Key、展示可直接访问的查询 URL、复制 URL 和复制原始 Key。
- 增加查询 Key 相关的弹窗状态重置、过期时间格式化、默认选择已启用房间、移动端样式适配和长房间名换行样式。
- 修复部署后 `/api/*` 请求被前端 SPA fallback 返回 `index.html` 的问题：前端 Worker 会先拦截 `/api/` 路径，通过 `API` service binding 转发到 `tjuecard-server`，并去掉 `/api` 前缀后再交给后端路由处理。
- 在 `web/wrangler.toml` 中新增 `API -> tjuecard-server` Worker 服务绑定。

## 变更原因

让用户可以为指定已订阅房间生成受限查询 Key，从而通过外部脚本或系统读取电量数据，不需要直接使用登录态访问 Dashboard。

同时保证生产环境同域名下的 `/api/electricity/query` 能正确命中后端 Worker，而不是被前端静态资源兜底成 HTML 页面。

## 影响范围

- 后端新增 `/api/electricity/query-key` 和 `/api/electricity/query` 能力。
- 前端 Dashboard 新增查询 Key 生成与复制入口。
- 前端 Worker 新增 `/api/*` 转发逻辑，生产环境需要先部署/已存在名为 `tjuecard-server` 的后端 Worker。
- 不改变原有房间订阅、自动查询、低电量通知流程。

## 如何使用

1. 登录 Dashboard，打开通知设置弹窗。
2. 展开“高级设置 / 生成查询 Key”。
3. 选择需要开放查询的已开启订阅房间，并选择 Key 有效期。
4. 点击“生成”，复制生成出的查询 URL 或原始 Key。
5. 如果复制的是查询 URL，可直接用浏览器或外部程序访问：

```http
GET https://tjuecard.ibuhub.com/api/electricity/query?key=<查询Key>
```

6. 如果复制的是原始 Key，可通过 `Authorization` Header 调用：

```bash
curl -H "Authorization: Bearer <查询Key>" \
  https://tjuecard.ibuhub.com/api/electricity/query
```

7. 返回结果示例：

```json
{
  "rooms": [
    {
      "id": 1,
      "alias_name": "52322",
      "full_name": "北洋园电控 - 宿舍楼 - 格园3斋 - 5层 - 523",
      "system_id": "1",
      "area_id": "2",
      "building_id": "1635",
      "floor_id": "1213",
      "room_id": "112130005",
      "last_query_time": "2026-03-15 12:24:31",
      "last_query_status": "success",
      "last_message": "Success",
      "last_electricity": 244.7,
      "next_query_time": "2026-03-16 00:24:31",
      "notification_threshold": -1,
      "is_active": 1,
      "unit": "kWh"
    }
  ]
}
```

说明：查询 Key 只能访问生成时选择且仍处于开启订阅状态的房间；Key 过期后需要重新生成。

## 验证

- 已在 `server/` 下执行 `npx tsc --noEmit`，检查通过。
- 已在 `web/` 下执行 `npm run build`，构建通过。
- 已在 `web/` 下执行 `npx wrangler deploy --dry-run`，确认 `env.API (tjuecard-server)` 和 `env.ASSETS` 绑定可被 Wrangler 识别。

- fix #17 