### PR TITLE
[codex] Proxy electricity query API requests

### DIFF
--- a/web/worker.js
+++ b/web/worker.js
@@ -2,6 +2,21 @@ export default {
     async fetch(request, env) {
         const url = new URL(request.url);
 
+        if (url.pathname.startsWith('/api/electricity/')) {
+            const apiBaseUrl = env.VITE_API_BASE_URL?.trim();
+            if (!apiBaseUrl) {
+                return new Response('VITE_API_BASE_URL is not configured', { status: 502 });
+            }
+
+            const apiUrl = new URL(apiBaseUrl);
+            const apiBasePath = apiUrl.pathname.replace(/\/$/, '');
+            const apiPath = url.pathname.replace(/^\/api/, '');
+            apiUrl.pathname = `${apiBasePath}${apiPath}`;
+            apiUrl.search = url.search;
+
+            return fetch(new Request(apiUrl, request));
+        }
+
         // Try to fetch the requested asset
         const response = await env.ASSETS.fetch(request);
 


### PR DESCRIPTION
## What changed

- Proxy `/api/electricity/*` requests in the frontend Worker before the SPA asset fallback runs.
- Forward those requests to the backend configured by the frontend Worker runtime `VITE_API_BASE_URL`.
- Strip the `/api` prefix so `/api/electricity/query` becomes `VITE_API_BASE_URL/electricity/query`.

## Why

After deployment, the generated same-origin query URL returned the frontend `index.html` instead of JSON because it was handled by the frontend SPA fallback instead of the backend Worker. This keeps the generated URL usable while preserving existing frontend routes such as `/tutorials`.

## Deployment note

The frontend Worker must have runtime env var `VITE_API_BASE_URL` configured to the backend API base URL. This is separate from Vite build-time replacement unless Cloudflare is already exposing the same variable to the Worker runtime.

## Validation

- `npm run build` in `web/`
- `npx wrangler deploy --dry-run` in `web/`